### PR TITLE
make decoding faster

### DIFF
--- a/types.go
+++ b/types.go
@@ -29,11 +29,11 @@ type BytesValue struct {
 	value []byte
 }
 
-func (b *BytesValue) GetType() Type {
+func (b BytesValue) GetType() Type {
 	return Bytes
 }
 
-func (b *BytesValue) GetValue() any {
+func (b BytesValue) GetValue() any {
 	return b.value
 }
 
@@ -41,10 +41,10 @@ type ListValue struct {
 	values []Value
 }
 
-func (a *ListValue) GetType() Type {
+func (a ListValue) GetType() Type {
 	return List
 }
 
-func (a *ListValue) GetValue() any {
+func (a ListValue) GetValue() any {
 	return a.values
 }


### PR DESCRIPTION
Avoid returning by reference in critical sections to trigger less garbage collector cycles.
From these benchmarks, it seems that the bigger the input is the more we gain from this change.
It starts with the short input being 35-40% faster to the larger one being more than x2.

Master benchmarks

```
BenchmarkDecode_String_Short
BenchmarkDecode_String_Short-10          	30701810	        38.57 ns/op
BenchmarkDecode_String_Medium
BenchmarkDecode_String_Medium-10         	30804642	        38.88 ns/op
BenchmarkDecode_String_Long
BenchmarkDecode_String_Long-10           	29927020	        39.61 ns/op
BenchmarkDecode_Array_Small
BenchmarkDecode_Array_Small-10           	 5565810	       215.0 ns/op
BenchmarkDecode_Array_Medium
BenchmarkDecode_Array_Medium-10          	  965722	      1211 ns/op
BenchmarkDecode_Array_Large
BenchmarkDecode_Array_Large-10           	  339132	      3355 ns/op
BenchmarkDecode_Array_Nested_Short
BenchmarkDecode_Array_Nested_Short-10    	 2880658	       409.3 ns/op
BenchmarkDecode_Array_Nested_Long
BenchmarkDecode_Array_Nested_Long-10     	  769512	      1571 ns/op
```

Current branch benchmarks

```
BenchmarkDecode_String_Short-10          	43988335	        24.72 ns/op
BenchmarkDecode_String_Medium
BenchmarkDecode_String_Medium-10         	47617786	        24.44 ns/op
BenchmarkDecode_String_Long
BenchmarkDecode_String_Long-10           	47017184	        25.05 ns/op
BenchmarkDecode_Array_Small
BenchmarkDecode_Array_Small-10           	10852027	       109.3 ns/op
BenchmarkDecode_Array_Medium
BenchmarkDecode_Array_Medium-10          	 2066397	       563.5 ns/op
BenchmarkDecode_Array_Large
BenchmarkDecode_Array_Large-10           	  746034	      1627 ns/op
BenchmarkDecode_Array_Nested_Short
BenchmarkDecode_Array_Nested_Short-10    	 5990282	       194.9 ns/op
BenchmarkDecode_Array_Nested_Long
BenchmarkDecode_Array_Nested_Long-10     	 1836169	       634.0 ns/op
```